### PR TITLE
add sepolia and amoy config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -204,7 +204,8 @@ steps:
     environment:
       AUTHORIZED_REPORTER: '0xa1135C5f1309eF9836679d31d7bea9846827f699'
       PRIVATE_KEY:
-        from_secret: deployer-prod-privatekey
+        # this wallet `0xdE4783337aC682ffF36714E8a78BA902Adfe270E` must be only used for x-chain deployment and only once per chain to keep addresses consistency across all x-chain networks
+        from_secret: x-chain-contract-deployer-prod-privatekey
       INFURA_API_KEY:
         from_secret: infura-api-key
       ETHERSCAN_API_KEY:

--- a/README.md
+++ b/README.md
@@ -148,15 +148,15 @@ npm run update-env-native -- --network bellecour
 - Polygon testnet Amoy
 
 ```
-SaltyForwarder deployed at: TODO
-SingleReporterOracle deployed at: TODO
+SaltyForwarder deployed at: 0xa02dEe31775e82E29e762bC69910ca3991f1a20F
+SingleReporterOracle deployed at: 0x4c1EA90575470267CE84887e8460E44b76f79Eb0
 ```
 
 - Ethereum testnet Sepolia
 
 ```
-SaltyForwarder deployed at: TODO
-SingleReporterOracle deployed at: TODO
+SaltyForwarder deployed at: 0xaf92191ee3afd45ae756443d03d55ec7c5cdfb89
+SingleReporterOracle deployed at: 0x0F669760bAe5edDE51a3e35456caF54E9184DeAe
 ```
 
 - Bellecour
@@ -190,6 +190,13 @@ SingleReporterOracle deployed at: 0x36dA71ccAd7A67053f0a4d9D5f55b725C9A25A3E
 ```
 SaltyForwarder deployed at: TODO
 SingleReporterOracle deployed at: TODO
+```
+
+- Ethereum Mainnet
+
+```
+SaltyForwarder deployed at: 0xc684E8645c8414812f22918146d72d1071E722AE
+SingleReporterOracle deployed at: 0x36dA71ccAd7A67053f0a4d9D5f55b725C9A25A3E
 ```
 
 - Bellecour

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -22,8 +22,16 @@ const config: HardhatUserConfig = {
       url: 'https://mainnet.infura.io/v3/' + INFURA_API_KEY,
       accounts: [PRIVATE_KEY],
     },
+    sepolia: {
+      url: 'https://sepolia.infura.io/v3/' + INFURA_API_KEY,
+      accounts: [PRIVATE_KEY],
+    },
     polygon: {
       url: 'https://polygon-mainnet.infura.io/v3/' + INFURA_API_KEY,
+      accounts: [PRIVATE_KEY],
+    },
+    amoy: {
+      url: 'https://rpc-amoy.polygon.technology',
       accounts: [PRIVATE_KEY],
     },
     bellecour: {
@@ -42,7 +50,9 @@ const config: HardhatUserConfig = {
   etherscan: {
     apiKey: {
       mainnet: ETHERSCAN_API_KEY,
+      sepolia: ETHERSCAN_API_KEY,
       polygon: POLYSCAN_API_KEY,
+      amoy: POLYSCAN_API_KEY,
       bellecour: 'abc',
     },
     customChains: [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -30,7 +30,7 @@ const config: HardhatUserConfig = {
       url: 'https://polygon-mainnet.infura.io/v3/' + INFURA_API_KEY,
       accounts: [PRIVATE_KEY],
     },
-    amoy: {
+    polygonAmoy: {
       url: 'https://rpc-amoy.polygon.technology',
       accounts: [PRIVATE_KEY],
     },
@@ -52,7 +52,7 @@ const config: HardhatUserConfig = {
       mainnet: ETHERSCAN_API_KEY,
       sepolia: ETHERSCAN_API_KEY,
       polygon: POLYSCAN_API_KEY,
-      amoy: POLYSCAN_API_KEY,
+      polygonAmoy: POLYSCAN_API_KEY,
       bellecour: 'abc',
     },
     customChains: [
@@ -62,6 +62,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: 'https://blockscout-bellecour.iex.ec/api',
           browserURL: 'https://blockscout-bellecour.iex.ec',
+        },
+      },
+      {
+        network: 'polygonAmoy',
+        chainId: 80002,
+        urls: {
+          apiURL: 'https://api-amoy.polygonscan.com/api',
+          browserURL: 'https://amoy.polygonscan.com/',
         },
       },
     ],


### PR DESCRIPTION
TODO:
- [x] config sepolia and amoy (NB: polygonAmoy added manually to avoid hardhat update from `hardhat@2.14.1` to `hardhat@^2.22.4`)
- [x] check dev deployment pipeline with `0x4c3f2bbb0939ec19b3ea467bfe9a7297c3df967a`
  - [x] sepolia
    - deployment job: https://drone-product.iex.ec/iExecBlockchainComputing/generic-oracle-contracts/154
    - SaltyForwarder: [0xaf92191ee3afd45ae756443d03d55ec7c5cdfb89](https://sepolia.etherscan.io/address/0xaf92191ee3afd45ae756443d03d55ec7c5cdfb89#code)
    - SingleReporterOracle: [0x0F669760bAe5edDE51a3e35456caF54E9184DeAe](https://sepolia.etherscan.io/address/0x0f669760bae5edde51a3e35456caf54e9184deae#code)
  - [x] amoy
    - deployment job: https://drone-product.iex.ec/iExecBlockchainComputing/generic-oracle-contracts/155
    - SaltyForwarder: [0xa02dEe31775e82E29e762bC69910ca3991f1a20F](https://amoy.polygonscan.com/address/0xa02dee31775e82e29e762bc69910ca3991f1a20f#code)
    - SingleReporterOracle: [0x4c1EA90575470267CE84887e8460E44b76f79Eb0](https://amoy.polygonscan.com/address/0x4c1ea90575470267ce84887e8460e44b76f79eb0#code)
- [x] add dev deployment addresses to readme 9089cc14fbb68b28541817471e985a4903d9d3f1
- [x] change prod deployment wallet for x-chain with `0xdE4783337aC682ffF36714E8a78BA902Adfe270E` 5ffd6f6d8d7a7cc036a5e831ef2f587b9a50a651